### PR TITLE
feat(time): 타임테이블 모달 api 연동

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -1,7 +1,6 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'references-empty': [2, 'never'], // 이슈 참조가 포함되어야 합니다.
     'scope-empty': [2, 'never'], // 반드시 scope를 포함해야 합니다.
     'scope-case': [2, 'always', 'lower-case'], // scope는 항상 소문자여야 합니다.
     'scope-enum': [
@@ -18,17 +17,13 @@ export default {
         'status',
         'config',
         'design-system',
-        'hooks',
         'icon',
         'utils',
         'ci',
+        'changeset',
+        'husky',
         'github',
       ],
     ],
-  },
-  parserPreset: {
-    parserOpts: {
-      issuePrefixes: ['#'], // 이슈 번호는 '#'으로 시작해야 합니다.
-    },
   },
 };

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Skip Husky Hooks
-        run: echo "HUSKY_SKIP_HOOKS=1" >> $GITHUB_ENV
-
       - name: Create Release Pull Request
         uses: changesets/action@v1
         env:

--- a/apps/time/package.json
+++ b/apps/time/package.json
@@ -13,6 +13,8 @@
     "@clab-platforms/design-system": "workspace:*",
     "@clab-platforms/icon": "workspace:^",
     "@clab-platforms/utils": "workspace:*",
+    "@tanstack/react-query": "^5.51.23",
+    "@tanstack/react-query-devtools": "^5.40.1",
     "jotai": "^2.9.2",
     "next": "14.1.4",
     "react": "^18",

--- a/apps/time/src/app/layout.tsx
+++ b/apps/time/src/app/layout.tsx
@@ -9,7 +9,7 @@ import './globals.css';
 const inter = Noto_Sans_KR({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: '경기타임',
+  title: '경기플러스',
   description: '경기대학교에 계신 모든 순간을 도와드릴게요.',
   icons: {
     icon: '/favicon.ico',

--- a/apps/time/src/shared/hooks/index.ts
+++ b/apps/time/src/shared/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useEditableSearchParams } from './useEditableSearchParams';
 export { default as useOutsideClick } from './useOutsideClick';
 export { default as useModalAction } from './useModalAction';
 export { default as useModalState } from './useModalState';
+export { default as useDebounce } from './useDebounce';

--- a/apps/time/src/shared/hooks/useDebounce.ts
+++ b/apps/time/src/shared/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+interface UseDebounceParams {
+  value: unknown;
+  delay: number;
+}
+
+export default function useDebounce({ value, delay }: UseDebounceParams) {
+  const [debouncedValue, setDebouncedValue] = useState<unknown>(value);
+
+  useEffect(() => {
+    const delayDebounceTimer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => clearTimeout(delayDebounceTimer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/apps/time/src/shared/hooks/useDebounce.ts
+++ b/apps/time/src/shared/hooks/useDebounce.ts
@@ -6,7 +6,7 @@ interface UseDebounceParams<T> {
 }
 
 export default function useDebounce<T>({ value, delay }: UseDebounceParams<T>) {
-  const [debouncedValue, setDebouncedValue] = useState<unknown>(value);
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
     const delayDebounceTimer = setTimeout(() => {

--- a/apps/time/src/shared/hooks/useDebounce.ts
+++ b/apps/time/src/shared/hooks/useDebounce.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 
-interface UseDebounceParams {
-  value: unknown;
+interface UseDebounceParams<T> {
+  value: T;
   delay: number;
 }
 
-export default function useDebounce({ value, delay }: UseDebounceParams) {
+export default function useDebounce<T>({ value, delay }: UseDebounceParams<T>) {
   const [debouncedValue, setDebouncedValue] = useState<unknown>(value);
 
   useEffect(() => {

--- a/apps/time/src/shared/utils/Providers.tsx
+++ b/apps/time/src/shared/utils/Providers.tsx
@@ -2,8 +2,18 @@
 
 import { PropsWithChildren } from 'react';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { Provider } from 'jotai';
 
 export default function Providers({ children }: PropsWithChildren) {
-  return <Provider>{children}</Provider>;
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Provider>{children}</Provider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
 }

--- a/apps/time/src/shared/utils/getAPIURL.ts
+++ b/apps/time/src/shared/utils/getAPIURL.ts
@@ -1,0 +1,3 @@
+export default function getAPIURL(endPoint: string) {
+  return new URL(`${process.env.NEXT_PUBLIC_API_URL}/api/${endPoint}`);
+}

--- a/apps/time/src/shared/utils/index.ts
+++ b/apps/time/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as Providers } from './Providers';
+export { default as getAPIURL } from './getAPIURL';

--- a/apps/time/src/widgets/menu/ui/Nav.tsx
+++ b/apps/time/src/widgets/menu/ui/Nav.tsx
@@ -33,7 +33,7 @@ const actions = [
   </button>,
 ] as const;
 
-const Nav = () => {
+export default function Nav() {
   return (
     <nav className="fixed top-0 w-full border-b bg-white">
       <div className="container flex h-14 items-center justify-between text-nowrap">
@@ -45,7 +45,9 @@ const Nav = () => {
             height={200}
             className="size-8"
           />
-          <h1 className="text-xl font-semibold">경기타임</h1>
+          <Link href="/">
+            <h1 className="select-none text-xl font-semibold">경기플러스</h1>
+          </Link>
         </div>
         <ul className="hidden w-3/5 items-center justify-center gap-4 text-sm sm:flex">
           {links.map((link) => link)}
@@ -56,6 +58,4 @@ const Nav = () => {
       </div>
     </nav>
   );
-};
-
-export default Nav;
+}

--- a/apps/time/src/widgets/time-table/api/endpoint.ts
+++ b/apps/time/src/widgets/time-table/api/endpoint.ts
@@ -1,6 +1,6 @@
 const TIMETABLE_ENDPOINT = {
-  getLectureList: 'api/v1/lecture/retrieve',
-  getMajorList: 'api/v1/lecture/retrieve/major',
+  lectureList: 'v1/lecture/retrieve',
+  majorList: 'v1/lecture/retrieve/major',
 };
 
 export default TIMETABLE_ENDPOINT;

--- a/apps/time/src/widgets/time-table/api/endpoint.ts
+++ b/apps/time/src/widgets/time-table/api/endpoint.ts
@@ -1,6 +1,6 @@
 const TIMETABLE_ENDPOINT = {
-  lectureList: 'v1/lecture/retrieve',
-  majorList: 'v1/lecture/retrieve/major',
-};
+  LECTURE_LIST: 'v1/lecture/retrieve',
+  MAJOR_LIST: 'v1/lecture/retrieve/major',
+} as const;
 
 export default TIMETABLE_ENDPOINT;

--- a/apps/time/src/widgets/time-table/api/endpoint.ts
+++ b/apps/time/src/widgets/time-table/api/endpoint.ts
@@ -1,0 +1,6 @@
+const TIMETABLE_ENDPOINT = {
+  getLectureList: 'api/v1/lecture/retrieve',
+  getMajorList: 'api/v1/lecture/retrieve/major',
+};
+
+export default TIMETABLE_ENDPOINT;

--- a/apps/time/src/widgets/time-table/api/getLectureList.ts
+++ b/apps/time/src/widgets/time-table/api/getLectureList.ts
@@ -1,4 +1,5 @@
 import { DayKor } from '@/shared/types';
+import { getAPIURL } from '@/shared/utils';
 import type {
   DayCampus,
   DayPeriod,
@@ -52,9 +53,7 @@ export interface GetLectureListResponse {
 export async function getLectureList({
   ...params
 }: GetLectureListParams): Promise<GetLectureListResponse> {
-  const apiURL = new URL(
-    `${process.env.NEXT_PUBLIC_SERVER_URL}/${TIMETABLE_ENDPOINT.getLectureList}`,
-  );
+  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.lectureList);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value) {

--- a/apps/time/src/widgets/time-table/api/getLectureList.ts
+++ b/apps/time/src/widgets/time-table/api/getLectureList.ts
@@ -53,7 +53,7 @@ export interface GetLectureListResponse {
 export async function getLectureList({
   ...params
 }: GetLectureListParams): Promise<GetLectureListResponse> {
-  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.lectureList);
+  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.LECTURE_LIST);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value) {

--- a/apps/time/src/widgets/time-table/api/getLectureList.ts
+++ b/apps/time/src/widgets/time-table/api/getLectureList.ts
@@ -21,7 +21,7 @@ export interface GetLectureListParams {
   limit: number;
 }
 
-export interface GetLectureListReponseValue {
+export interface GetLectureListResponseValue {
   id: number;
   campus: string;
   category: string;
@@ -43,7 +43,7 @@ export interface GetLectureListReponseValue {
 export interface GetLectureListResponse {
   success: boolean;
   data: {
-    values: GetLectureListReponseValue[];
+    values: GetLectureListResponseValue[];
   };
   hasPrevious: boolean;
   hasNext: boolean;

--- a/apps/time/src/widgets/time-table/api/getLectureList.ts
+++ b/apps/time/src/widgets/time-table/api/getLectureList.ts
@@ -26,15 +26,15 @@ export interface GetLectureListResponseValue {
   campus: string;
   category: string;
   code: string;
-  credit: 0;
-  grade: 0;
+  credit: number;
+  grade: number;
   groupName: string;
   isExceeded: true;
   major: string;
   name: string;
   professor: string;
   room: string;
-  year: 0;
+  year: number;
   semester: string;
   time: string;
   type: LectureKey;

--- a/apps/time/src/widgets/time-table/api/getLectureList.ts
+++ b/apps/time/src/widgets/time-table/api/getLectureList.ts
@@ -1,0 +1,75 @@
+import { DayKor } from '@/shared/types';
+import type {
+  DayCampus,
+  DayPeriod,
+  Grade,
+  LectureKey,
+  NightCampus,
+  NightPeriod,
+} from '@/widgets/time-table';
+import { TIMETABLE_ENDPOINT } from '@/widgets/time-table';
+
+export interface GetLectureListParams {
+  campus: (DayCampus | NightCampus)[];
+  type: LectureKey[];
+  grade: Grade[];
+  day: DayKor[];
+  time: (DayPeriod | NightPeriod)[];
+  major: string[];
+  lectureName: string;
+  cursor: number;
+  limit: number;
+}
+
+export interface GetLectureListReponseValue {
+  id: number;
+  campus: string;
+  category: string;
+  code: string;
+  credit: 0;
+  grade: 0;
+  groupName: string;
+  isExceeded: true;
+  major: string;
+  name: string;
+  professor: string;
+  room: string;
+  year: 0;
+  semester: string;
+  time: string;
+  type: LectureKey;
+}
+
+export interface GetLectureListResponse {
+  success: boolean;
+  data: {
+    values: GetLectureListReponseValue[];
+  };
+  hasPrevious: boolean;
+  hasNext: boolean;
+}
+
+export async function getLectureList({
+  ...params
+}: GetLectureListParams): Promise<GetLectureListResponse> {
+  const apiURL = new URL(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/${TIMETABLE_ENDPOINT.getLectureList}`,
+  );
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      apiURL.searchParams.set(
+        key,
+        Array.isArray(value) ? value.join(',') : String(value),
+      );
+    }
+  });
+
+  const res = await fetch(apiURL);
+
+  if (!res.ok) {
+    throw new Error('강의 정보 불러오기에 실패했습니다.');
+  }
+
+  return res.json();
+}

--- a/apps/time/src/widgets/time-table/api/getMajorList.ts
+++ b/apps/time/src/widgets/time-table/api/getMajorList.ts
@@ -13,7 +13,7 @@ export interface GetMajorListResponse {
 export async function getMajorList({
   major,
 }: GetMajorListParams): Promise<GetMajorListResponse> {
-  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.majorList);
+  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.MAJOR_LIST);
 
   apiURL.searchParams.set('major', major);
 

--- a/apps/time/src/widgets/time-table/api/getMajorList.ts
+++ b/apps/time/src/widgets/time-table/api/getMajorList.ts
@@ -1,3 +1,4 @@
+import { getAPIURL } from '@/shared/utils';
 import { TIMETABLE_ENDPOINT } from '@/widgets/time-table';
 
 export interface GetMajorListParams {
@@ -12,9 +13,7 @@ export interface GetMajorListResponse {
 export async function getMajorList({
   major,
 }: GetMajorListParams): Promise<GetMajorListResponse> {
-  const apiURL = new URL(
-    `${process.env.NEXT_PUBLIC_SERVER_URL}/${TIMETABLE_ENDPOINT.getMajorList}`,
-  );
+  const apiURL = getAPIURL(TIMETABLE_ENDPOINT.majorList);
 
   apiURL.searchParams.set('major', major);
 

--- a/apps/time/src/widgets/time-table/api/getMajorList.ts
+++ b/apps/time/src/widgets/time-table/api/getMajorList.ts
@@ -1,0 +1,28 @@
+import { TIMETABLE_ENDPOINT } from '@/widgets/time-table';
+
+export interface GetMajorListParams {
+  major: string;
+}
+
+export interface GetMajorListResponse {
+  success: boolean;
+  data: string[];
+}
+
+export async function getMajorList({
+  major,
+}: GetMajorListParams): Promise<GetMajorListResponse> {
+  const apiURL = new URL(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/${TIMETABLE_ENDPOINT.getMajorList}`,
+  );
+
+  apiURL.searchParams.set('major', major);
+
+  const res = await fetch(apiURL);
+
+  if (!res.ok) {
+    throw new Error('전공 리스트 불러오기에 실패했습니다.');
+  }
+
+  return res.json();
+}

--- a/apps/time/src/widgets/time-table/api/index.ts
+++ b/apps/time/src/widgets/time-table/api/index.ts
@@ -1,0 +1,3 @@
+export { default as TIMETABLE_ENDPOINT } from './endpoint';
+export * from './getLectureList';
+export * from './getMajorList';

--- a/apps/time/src/widgets/time-table/index.ts
+++ b/apps/time/src/widgets/time-table/index.ts
@@ -1,3 +1,4 @@
 export * from './ui';
 export * from './model';
 export * from './types';
+export * from './api';

--- a/apps/time/src/widgets/time-table/model/constants/period.ts
+++ b/apps/time/src/widgets/time-table/model/constants/period.ts
@@ -1,4 +1,4 @@
-const DAY_PERIOD = {
+export const DAY_PERIOD = {
   '1': {
     start: { hour: 9, minute: 0 },
     end: { hour: 9, minute: 50 },
@@ -91,7 +91,7 @@ const DAY_PERIOD = {
   },
 } as const;
 
-const NIGHT_PERIOD = {
+export const NIGHT_PERIOD = {
   '1': {
     start: { hour: 17, minute: 50 },
     end: { hour: 18, minute: 35 },
@@ -124,7 +124,7 @@ const NIGHT_PERIOD = {
   },
 } as const;
 
-const DAY_PERIOD_ARRAY = Object.entries(DAY_PERIOD).sort(
+export const DAY_PERIOD_ARRAY = Object.entries(DAY_PERIOD).sort(
   ([, periodA], [, periodB]) => {
     const timeA = periodA.start.hour * 60 + periodA.start.minute;
     const timeB = periodB.start.hour * 60 + periodB.start.minute;
@@ -133,7 +133,7 @@ const DAY_PERIOD_ARRAY = Object.entries(DAY_PERIOD).sort(
   },
 );
 
-const NIGHT_PERIOD_ARRAY = Object.entries(NIGHT_PERIOD).sort(
+export const NIGHT_PERIOD_ARRAY = Object.entries(NIGHT_PERIOD).sort(
   ([, periodA], [, periodB]) => {
     const timeA = periodA.start.hour * 60 + periodA.start.minute;
     const timeB = periodB.start.hour * 60 + periodB.start.minute;
@@ -142,18 +142,4 @@ const NIGHT_PERIOD_ARRAY = Object.entries(NIGHT_PERIOD).sort(
   },
 );
 
-const DAY_STATUS = {
-  day: '주간',
-  night: '야간',
-} as const;
-
-const SPECIAL_PERIOD = ['이러닝', '교외수업', '사회봉사'] as const;
-
-export {
-  DAY_PERIOD,
-  NIGHT_PERIOD,
-  SPECIAL_PERIOD,
-  DAY_PERIOD_ARRAY,
-  NIGHT_PERIOD_ARRAY,
-  DAY_STATUS,
-};
+export const SPECIAL_PERIOD = ['이러닝', '교외수업', '사회봉사'] as const;

--- a/apps/time/src/widgets/time-table/model/constants/region.ts
+++ b/apps/time/src/widgets/time-table/model/constants/region.ts
@@ -3,4 +3,20 @@ export const REGION = {
   campus2: '서울',
 } as const;
 
+export const DAY_STATUS = {
+  day: '주간',
+  night: '야간',
+} as const;
+
+export const CAMPUS_STATUS = {
+  day: [
+    `${REGION.campus1}${DAY_STATUS.day}`,
+    `${REGION.campus2}${DAY_STATUS.day}`,
+  ],
+  night: [
+    `${REGION.campus1}${DAY_STATUS.night}`,
+    `${REGION.campus2}${DAY_STATUS.night}`,
+  ],
+} as const;
+
 export const REGION_VALUE_ARRAY = Object.values(REGION);

--- a/apps/time/src/widgets/time-table/model/hooks/index.ts
+++ b/apps/time/src/widgets/time-table/model/hooks/index.ts
@@ -1,1 +1,2 @@
+export { default as timeTableQueryKeys } from './timeTableQueryKeys';
 export { default as useTimeTableParams } from './useTimeTableParams';

--- a/apps/time/src/widgets/time-table/model/hooks/index.ts
+++ b/apps/time/src/widgets/time-table/model/hooks/index.ts
@@ -1,2 +1,4 @@
 export { default as timeTableQueryKeys } from './timeTableQueryKeys';
 export { default as useTimeTableParams } from './useTimeTableParams';
+export { default as useMajorList } from './useMajorList';
+export { default as useLectureList } from './useLectureList';

--- a/apps/time/src/widgets/time-table/model/hooks/timeTableQueryKeys.ts
+++ b/apps/time/src/widgets/time-table/model/hooks/timeTableQueryKeys.ts
@@ -1,0 +1,8 @@
+import { GetLectureListParams, GetMajorListParams } from '@/widgets/time-table';
+
+const timeTableQueryKeys = {
+  getLectureList: (params: GetLectureListParams) => ['getLectureList', params],
+  getMajorList: (params: GetMajorListParams) => ['getMajorList', params],
+};
+
+export default timeTableQueryKeys;

--- a/apps/time/src/widgets/time-table/model/hooks/useLectureList.ts
+++ b/apps/time/src/widgets/time-table/model/hooks/useLectureList.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import {
+  type GetLectureListParams,
+  getLectureList,
+  timeTableQueryKeys,
+} from '@/widgets/time-table';
+
+export default function useLectureList({ ...params }: GetLectureListParams) {
+  return useSuspenseQuery({
+    queryKey: timeTableQueryKeys.getLectureList(params),
+    queryFn: () => getLectureList(params),
+  });
+}

--- a/apps/time/src/widgets/time-table/model/hooks/useMajorList.ts
+++ b/apps/time/src/widgets/time-table/model/hooks/useMajorList.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  type GetMajorListParams,
+  getMajorList,
+  timeTableQueryKeys,
+} from '@/widgets/time-table';
+
+export default function useMajorList({ major }: GetMajorListParams) {
+  const { data } = useQuery({
+    queryKey: timeTableQueryKeys.getMajorList({ major }),
+    queryFn: () => getMajorList({ major }),
+    enabled: major.length > 0,
+  });
+
+  return data ? data.data : [];
+}

--- a/apps/time/src/widgets/time-table/types/day-status.ts
+++ b/apps/time/src/widgets/time-table/types/day-status.ts
@@ -1,5 +1,0 @@
-import { DAY_STATUS } from '@/widgets/time-table';
-
-type DayStatus = keyof typeof DAY_STATUS;
-
-export type { DayStatus };

--- a/apps/time/src/widgets/time-table/types/index.ts
+++ b/apps/time/src/widgets/time-table/types/index.ts
@@ -1,4 +1,3 @@
-export * from './day-status';
 export * from './grade';
 export * from './period';
 export * from './lecture';

--- a/apps/time/src/widgets/time-table/types/region.ts
+++ b/apps/time/src/widgets/time-table/types/region.ts
@@ -1,3 +1,9 @@
-import { REGION } from '@/widgets/time-table';
+import { CAMPUS_STATUS, DAY_STATUS, REGION } from '@/widgets/time-table';
 
 export type Region = (typeof REGION)[keyof typeof REGION];
+
+export type DayStatus = keyof typeof DAY_STATUS;
+
+export type DayCampus = (typeof CAMPUS_STATUS.day)[number];
+
+export type NightCampus = (typeof CAMPUS_STATUS.night)[number];

--- a/apps/time/src/widgets/time-table/ui/TimeTableLectureTable.tsx
+++ b/apps/time/src/widgets/time-table/ui/TimeTableLectureTable.tsx
@@ -1,0 +1,119 @@
+import { Suspense, memo } from 'react';
+
+import {
+  type GetLectureListParams,
+  type GetLectureListResponseValue,
+  useLectureList,
+} from '@/widgets/time-table';
+
+interface TimeTableLectureTableProps {
+  selectedValues: GetLectureListParams;
+}
+
+interface TimeTableLectureTableItemProps {
+  lecture: GetLectureListResponseValue;
+}
+
+const LECTURE_TABLE_ROW_HEADER = [
+  '캠퍼스',
+  '카테고리',
+  '과목코드',
+  '학점',
+  '학년',
+  '전공',
+  '수업명',
+  '담당교수',
+  '학기',
+  '시간',
+  '수업구분',
+] as const;
+
+function TimeTableLectureItem({ lecture }: TimeTableLectureTableItemProps) {
+  return (
+    <tr className="divide-x divide-gray-300 text-center">
+      <td>{lecture.campus}</td>
+      <td>{lecture.category}</td>
+      <td>{lecture.code}</td>
+      <td>{lecture.credit}</td>
+      <td>{lecture.grade ?? '-'}</td>
+      <td>{lecture.major !== 'None' ? lecture.major : '-'}</td>
+      <td>{lecture.name}</td>
+      <td>{lecture.professor}</td>
+      <td>{lecture.semester}</td>
+      <td>{lecture.time}</td>
+      <td>{lecture.groupName}</td>
+    </tr>
+  );
+}
+
+function TimeTableLectureContent({
+  selectedValues,
+}: TimeTableLectureTableProps) {
+  const { data } = useLectureList({
+    campus: selectedValues.campus,
+    type: selectedValues.type,
+    grade: selectedValues.grade,
+    day: selectedValues.day,
+    time: selectedValues.time,
+    major: selectedValues.major,
+    lectureName: selectedValues.lectureName,
+    cursor: 0,
+    limit: 10,
+  });
+  const lectureList = data.data.values;
+
+  return (
+    <>
+      {lectureList.length ? (
+        <>
+          {...lectureList.map((lecture) => (
+            <TimeTableLectureItem
+              key={`lecture-${lecture.id}`}
+              lecture={lecture}
+            />
+          ))}
+        </>
+      ) : (
+        <tr>
+          <td colSpan={LECTURE_TABLE_ROW_HEADER.length} className="text-center">
+            검색 결과가 없습니다
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function TimeTableLectureTable({ selectedValues }: TimeTableLectureTableProps) {
+  return (
+    <table className="mt-3 w-full table-auto border-collapse border border-gray-400 text-sm">
+      <thead className="w-full border border-gray-400 text-center">
+        <tr className="divide-x divide-gray-400 border border-gray-400 bg-gray-100">
+          {LECTURE_TABLE_ROW_HEADER.map((header) => (
+            <td className="py-2" key={header}>
+              {header}
+            </td>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="h-80 w-full divide-y divide-gray-300 overflow-y-scroll">
+        <Suspense
+          fallback={
+            <tr>
+              <td
+                colSpan={LECTURE_TABLE_ROW_HEADER.length}
+                className="text-center"
+              >
+                강의 정보를 불러오고 있습니다
+              </td>
+            </tr>
+          }
+        >
+          <TimeTableLectureContent selectedValues={selectedValues} />
+        </Suspense>
+      </tbody>
+    </table>
+  );
+}
+
+export default memo(TimeTableLectureTable);

--- a/apps/time/src/widgets/time-table/ui/TimeTableModal.tsx
+++ b/apps/time/src/widgets/time-table/ui/TimeTableModal.tsx
@@ -74,11 +74,11 @@ interface TimeTableModalDropdownButtonProps
 
 interface TimeTableModalMajorInputProps {
   selectedMajor: string[];
-  handleMajorInput: (major: string) => void;
+  handleMajorInputChange: (major: string) => void;
 }
 
 interface TimeTableModalLectureSearchInputProps {
-  handleLectureSearchInput: (keyword: string) => void;
+  handleLectureSearchInputChange: (keyword: string) => void;
 }
 
 interface TimeTableModalProps<T> {
@@ -227,7 +227,7 @@ const TimeTableModalDropdownButton = memo(
 
 const TimeTableModalMajorInput = memo(function TimeTableModalMajorInput({
   selectedMajor,
-  handleMajorInput,
+  handleMajorInputChange,
 }: TimeTableModalMajorInputProps) {
   const [inputValue, setInputValue] = useState('');
   const [open, setOpen] = useState<boolean>(false);
@@ -247,7 +247,7 @@ const TimeTableModalMajorInput = memo(function TimeTableModalMajorInput({
       {...selectedMajor.map((major) => (
         <TimeTableModalDropdownButton
           key={major}
-          onClick={() => handleMajorInput(major)}
+          onClick={() => handleMajorInputChange(major)}
           value={major}
         />
       ))}
@@ -276,7 +276,7 @@ const TimeTableModalMajorInput = memo(function TimeTableModalMajorInput({
             {...findMajorList.map((major) => (
               <Modal.DropdownItem
                 key={major}
-                onClick={() => handleMajorInput(major)}
+                onClick={() => handleMajorInputChange(major)}
                 selected={selectedMajor.includes(major)}
               >
                 {major}
@@ -290,7 +290,7 @@ const TimeTableModalMajorInput = memo(function TimeTableModalMajorInput({
 });
 
 const TimeTableLectureSearchInput = memo(function TimeTableLectureSearchInput({
-  handleLectureSearchInput,
+  handleLectureSearchInputChange,
 }: TimeTableModalLectureSearchInputProps) {
   return (
     <Modal.Item title="강의 검색">
@@ -298,7 +298,7 @@ const TimeTableLectureSearchInput = memo(function TimeTableLectureSearchInput({
         inputClassName="border-gray-400 px-1 px-1.5 rounded-md"
         placeholder="강의명을 입력해주세요"
         onChange={(event) =>
-          handleLectureSearchInput(event.currentTarget.value)
+          handleLectureSearchInputChange(event.currentTarget.value)
         }
       />
     </Modal.Item>
@@ -421,12 +421,14 @@ export default function TimeTableModal<
             />
             <TimeTableModalMajorInput
               selectedMajor={selectedMajor}
-              handleMajorInput={(major) =>
+              handleMajorInputChange={(major) =>
                 handleFilterItem(major, selectedMajor, setSelectedMajor)
               }
             />
             <TimeTableLectureSearchInput
-              handleLectureSearchInput={(keyword) => setSearchKeyword(keyword)}
+              handleLectureSearchInputChange={(keyword) =>
+                setSearchKeyword(keyword)
+              }
             />
             <TimeTableLectureTable
               selectedValues={{

--- a/apps/time/src/widgets/time-table/ui/TimeTableModal.tsx
+++ b/apps/time/src/widgets/time-table/ui/TimeTableModal.tsx
@@ -443,7 +443,7 @@ export default function TimeTableModal<
                 day: selectedDay,
                 time: selectedPeriod,
                 major: selectedMajor,
-                lectureName: debouncedSearchKeyword as string,
+                lectureName: debouncedSearchKeyword,
                 cursor: 0,
                 limit: 10,
               }}

--- a/apps/time/src/widgets/time-table/ui/index.ts
+++ b/apps/time/src/widgets/time-table/ui/index.ts
@@ -4,3 +4,4 @@ export { default as TimeTableLayout } from './TimeTableLayout';
 export { default as TimeTableHeader } from './TimeTableHeader';
 export { default as TimeTableModal } from './TimeTableModal';
 export { default as TimeTableContainer } from './TimeTableContainer';
+export { default as TimeTableLectureTable } from './TimeTableLectureTable';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,12 @@ importers:
       '@clab-platforms/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@tanstack/react-query':
+        specifier: ^5.51.23
+        version: 5.51.23(react@18.2.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.40.1
+        version: 5.45.1(@tanstack/react-query@5.51.23(react@18.2.0))(react@18.2.0)
       jotai:
         specifier: ^2.9.2
         version: 2.9.2(@types/react@18.2.77)(react@18.2.0)
@@ -2647,6 +2653,9 @@ packages:
   '@tanstack/query-core@5.29.0':
     resolution: {integrity: sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==}
 
+  '@tanstack/query-core@5.51.21':
+    resolution: {integrity: sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==}
+
   '@tanstack/query-core@5.51.9':
     resolution: {integrity: sha512-HsAwaY5J19MD18ykZDS3aVVh+bAt0i7m6uQlFC2b77DLV9djo+xEN7MWQAQQTR8IM+7r/zbozTQ7P0xr0bHuew==}
 
@@ -2661,6 +2670,11 @@ packages:
 
   '@tanstack/react-query@5.29.2':
     resolution: {integrity: sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@tanstack/react-query@5.51.23':
+    resolution: {integrity: sha512-CfJCfX45nnVIZjQBRYYtvVMIsGgWLKLYC4xcUiYEey671n1alvTZoCBaU9B85O8mF/tx9LPyrI04A6Bs2THv4A==}
     peerDependencies:
       react: ^18.0.0
 
@@ -9778,9 +9792,17 @@ snapshots:
 
   '@tanstack/query-core@5.29.0': {}
 
+  '@tanstack/query-core@5.51.21': {}
+
   '@tanstack/query-core@5.51.9': {}
 
   '@tanstack/query-devtools@5.37.1': {}
+
+  '@tanstack/react-query-devtools@5.45.1(@tanstack/react-query@5.51.23(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.37.1
+      '@tanstack/react-query': 5.51.23(react@18.2.0)
+      react: 18.2.0
 
   '@tanstack/react-query-devtools@5.45.1(@tanstack/react-query@5.51.9(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -9791,6 +9813,11 @@ snapshots:
   '@tanstack/react-query@5.29.2(react@18.2.0)':
     dependencies:
       '@tanstack/query-core': 5.29.0
+      react: 18.2.0
+
+  '@tanstack/react-query@5.51.23(react@18.2.0)':
+    dependencies:
+      '@tanstack/query-core': 5.51.21
       react: 18.2.0
 
   '@tanstack/react-query@5.51.9(react@18.2.0)':
@@ -11424,7 +11451,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -11469,7 +11496,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -11502,6 +11529,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
@@ -11529,7 +11566,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -11539,7 +11576,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

> #97

강의 필터링을 위한 타임테이블 모달 컴포넌트에 api 연결을 완료했습니다.

## Tasks

- 상수들을 재정리했습니다 (주간/야간을 나타내는 `DAY_STATUS`가 `period.ts`에 있는건 부자연스럽다고 판단)
- 백엔드 api를 적용하여 강의 정보를 필터링하는 기능을 구현했습니다.
- react-query / react-query-devtools 패키지를 설치하였고, 해당 내용을 적용했습니다.
- `useSuspenseQuery`와 `Suspense`를 사용하여 데이터 로딩시 fallback 처리를 진행했습니다.
- `useDebounce` 유틸 훅을 만들어 input 입력 시 일어나는 데이터 패칭을 최적화했습니다.
- `queryKey factory`를 적용하여 쿼리 키를 관리하도록 하였습니다.
- `pills-input` 컴포넌트를 직접 구현하여 전공 선택시의 편의성을 높였습니다.

## ETC

- 아직 모바일 반응형 사이징 최적화가 되지 않았습니다.
- 현재는 고정적으로 데이터를 받아오고있으나, 무한 스크롤 적용 예정입니다.
- 일부 디자인이 추가적으로 수정될 예정입니다.
- `Modal`과 관련된 컴포넌트들의 일부가 중복된 로직들이 존재하는데, 이는 추후 재설계하여 공용 DS 파트로 분리할 예정입니다.
- `Suspensive` 라이브러리를 사용하여 `ErrorBoundary`와 `Suspsense` 컴포넌트를 적용할 예정입니다.

## Screenshot

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/5cca510d-6c9c-425b-9df3-9f193c3c0b4e">