### PR TITLE
feat(auth): add test service for staging members

### DIFF
--- a/.changeset/tricky-teachers-doubt.md
+++ b/.changeset/tricky-teachers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@clab-platforms/auth": patch
+---
+
+feat(auth): add test service for staging members

--- a/apps/auth/src/utils/service.ts
+++ b/apps/auth/src/utils/service.ts
@@ -1,6 +1,6 @@
 import type { Token } from '@type/server';
 
-export type ServiceCode = 'play' | 'members' | 'dev';
+export type ServiceCode = 'play' | 'members' | 'dev' | 'test';
 
 export interface ServiceMap {
   url: string;
@@ -11,6 +11,10 @@ const SERVICE_MAP: Record<ServiceCode, ServiceMap> = {
   dev: { url: 'http://localhost:6002/auth', name: '개발환경' },
   play: { url: 'https://play.clab.page/auth', name: '플레이' },
   members: { url: 'https://members.clab.page/auth', name: '멤버스' },
+  test: {
+    url: 'https://members.test.clab.page/auth',
+    name: '스테이징 멤버스',
+  },
 } as const;
 /**
  * 연결되는 서비스의 정보를 가져옵니다.


### PR DESCRIPTION
## Summary

> #217 

Auth 시스템에 스테이징 서버를 연결했어요. 이제 Auth를 통해 스테이징 테스트 서버에 로그인 할 수 있어요.