### PR TITLE
feat(member): 멤버 권한 관리 기능 추가

### DIFF
--- a/.changeset/chilly-eagles-behave.md
+++ b/.changeset/chilly-eagles-behave.md
@@ -1,0 +1,5 @@
+---
+"@clab-platforms/member": patch
+---
+
+feat(member): 멤버 권한 관리 기능 추가

--- a/apps/member/src/api/member.ts
+++ b/apps/member/src/api/member.ts
@@ -11,6 +11,9 @@ import type {
   MemberInfo,
   MemberProfileRequestType,
   MemberProfileType,
+  MemberRoleListType,
+  MemberRoleRequestType,
+  RoleLevelKey,
 } from '@type/member';
 
 import { server } from './server';
@@ -26,6 +29,20 @@ export interface PatchUserInfoParams {
   body: MemberProfileRequestType;
   file?: File; // 프로필 이미지
 }
+
+export interface GetMemberRoleParams extends WithPaginationParams {
+  memberId?: string;
+  memberName?: string;
+  role?: RoleLevelKey;
+  sortBy?: string;
+  sortDirection?: string;
+}
+
+export interface PatchMemberRoleParams {
+  memberId: string;
+  body: MemberRoleRequestType;
+}
+
 /**
  * 멤버 정보 조회
  */
@@ -69,6 +86,51 @@ export async function patchUserInfo({
     BaseResponse<string>
   >({
     url: END_POINT.MY_INFO_EDIT(id),
+    body,
+  });
+
+  return data;
+}
+
+/**
+ * 멤버 레밸 조회
+ */
+export async function getMemberRole({
+  memberId,
+  memberName,
+  role,
+  page,
+  size,
+  sortBy,
+  sortDirection,
+}: GetMemberRoleParams) {
+  const { data } = await server.get<ResponsePagination<MemberRoleListType>>({
+    url: createPagination(END_POINT.MEMBER_LEVEL, {
+      memberId,
+      memberName,
+      role,
+      page,
+      size,
+      sortBy,
+      sortDirection,
+    }),
+  });
+
+  return data;
+}
+
+/**
+ * 멤버 레벨 수정
+ */
+export async function patchMemberRole({
+  memberId,
+  body,
+}: PatchMemberRoleParams) {
+  const { data } = await server.patch<
+    MemberRoleRequestType,
+    BaseResponse<string>
+  >({
+    url: END_POINT.MEMBER_LEVEL_EDIT(memberId),
     body,
   });
 

--- a/apps/member/src/components/common/Avatar/Avatar.tsx
+++ b/apps/member/src/components/common/Avatar/Avatar.tsx
@@ -1,9 +1,10 @@
 import { cn } from '@clab-platforms/utils';
 
+import { ROLE_LEVEL } from '@constants/state';
 import { createImageUrl } from '@utils/api';
 
 import type { VariantSize } from '@type/component';
-import type { RoleLevel } from '@type/member';
+import type { RoleLevelType } from '@type/member';
 
 import Image from '../Image/Image';
 
@@ -13,7 +14,8 @@ const SIZE_STYLES = {
   lg: 'size-32',
 } as const;
 
-const RING_STYLES = {
+const RING_STYLES: Record<RoleLevelType, string> = {
+  0: '',
   1: 'ring-gray-500',
   2: 'ring-purple-500',
   3: 'ring-red-500',
@@ -23,12 +25,12 @@ interface AvatarProps {
   className?: string;
   src?: string | null;
   size?: Extract<VariantSize, 'sm' | 'md' | 'lg'>;
-  roleLevel: RoleLevel;
+  roleLevel: RoleLevelType;
 }
 
 const Avatar = ({ className, src, size = 'md', roleLevel }: AvatarProps) => {
   const sizeStyled = SIZE_STYLES[size];
-  const ringStyled = RING_STYLES[roleLevel ?? 1];
+  const ringStyled = RING_STYLES[roleLevel ?? ROLE_LEVEL.USER];
 
   return (
     <div

--- a/apps/member/src/components/common/Avatar/Avatar.tsx
+++ b/apps/member/src/components/common/Avatar/Avatar.tsx
@@ -15,7 +15,6 @@ const SIZE_STYLES = {
 } as const;
 
 const RING_STYLES: Record<RoleLevelType, string> = {
-  0: '',
   1: 'ring-gray-500',
   2: 'ring-purple-500',
   3: 'ring-red-500',

--- a/apps/member/src/components/common/Nav/Nav.tsx
+++ b/apps/member/src/components/common/Nav/Nav.tsx
@@ -6,6 +6,7 @@ import { cn } from '@clab-platforms/utils';
 
 import { IS_DEVELOPMENT } from '@constants/environment';
 import { PATH } from '@constants/path';
+import { ROLE_LEVEL } from '@constants/state';
 import useModal from '@hooks/common/useModal';
 import { useMyProfile } from '@hooks/queries';
 
@@ -82,7 +83,7 @@ const Nav = () => {
             >
               회비
             </Menubar.Item>
-            {data.roleLevel! >= 2 && (
+            {data.roleLevel! >= ROLE_LEVEL.ADMIN && (
               <>
                 <Menubar.Item
                   selected={pathName.startsWith(PATH.MANAGE)}

--- a/apps/member/src/components/common/Post/Post.tsx
+++ b/apps/member/src/components/common/Post/Post.tsx
@@ -1,10 +1,11 @@
 import { cn, toDecodeHTMLEntities } from '@clab-platforms/utils';
 
 import { SERVICE_NAME } from '@constants/environment';
+import { ROLE_LEVEL } from '@constants/state';
 import { formattedDate } from '@utils/date';
 
 import { StrictPropsWithChildren } from '@type/component';
-import type { RoleLevel } from '@type/member';
+import type { RoleLevelType } from '@type/member';
 
 import Avatar from '../Avatar/Avatar';
 import Share from '../Share/Share';
@@ -18,7 +19,7 @@ interface PostHeaderProps {
   createdAt: string;
   src?: string | null;
   writer?: string;
-  roleLevel?: RoleLevel;
+  roleLevel?: RoleLevelType;
 }
 
 const Post = ({ className, children }: Props) => {
@@ -29,7 +30,7 @@ const PostHead = ({
   title,
   src,
   writer = SERVICE_NAME,
-  roleLevel = 1,
+  roleLevel = ROLE_LEVEL.USER,
   createdAt,
 }: PostHeaderProps) => {
   return (

--- a/apps/member/src/components/common/Sidebar/Sidebar.tsx
+++ b/apps/member/src/components/common/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { CloseOutline, MenuOutline } from '@clab-platforms/icon';
 import { cn } from '@clab-platforms/utils';
 
 import { PATH } from '@constants/path';
+import { ROLE_LEVEL } from '@constants/state';
 import { useMyProfile } from '@hooks/queries';
 
 const Sidebar = () => {
@@ -91,7 +92,7 @@ const Sidebar = () => {
           >
             회비
           </Menubar.Item>
-          {data.roleLevel! >= 2 && (
+          {data.roleLevel! >= ROLE_LEVEL.ADMIN && (
             <>
               <Menubar.Item
                 selected={pathName.startsWith(PATH.MANAGE)}

--- a/apps/member/src/components/community/CommunityPostsSection/CommunityPostsSection.tsx
+++ b/apps/member/src/components/community/CommunityPostsSection/CommunityPostsSection.tsx
@@ -32,7 +32,7 @@ const CommunityPostsSection = ({
   size: defaultSize,
 }: Props) => {
   const navigate = useNavigate();
-  const { page, size, handlePageChange } = usePagination(defaultSize);
+  const { page, size, handlePageChange } = usePagination({ defaultSize });
   const { data } = useBoardByCategory({ category: type, page, size });
 
   const handleBoardClick = useCallback(

--- a/apps/member/src/components/library/LibraryBooksSection/LibraryBooksSection.tsx
+++ b/apps/member/src/components/library/LibraryBooksSection/LibraryBooksSection.tsx
@@ -7,7 +7,7 @@ import { useBooks } from '@hooks/queries/book';
 import BookCard from '../BookCard/BookCard';
 
 const LibraryBooksSection = () => {
-  const { page, size, handlePageChange } = usePagination(16);
+  const { page, size, handlePageChange } = usePagination({ defaultSize: 16 });
 
   const { data } = useBooks(page, size);
 

--- a/apps/member/src/components/manage/ManageActivitySection/ManageActivitySection.tsx
+++ b/apps/member/src/components/manage/ManageActivitySection/ManageActivitySection.tsx
@@ -3,12 +3,14 @@ import { useState } from 'react';
 import { Menubar, Table } from '@clab-platforms/design-system';
 
 import ActionButton from '@components/common/ActionButton/ActionButton';
+import Pagination from '@components/common/Pagination/Pagination';
 import { Section } from '@components/common/Section';
 import ActivityInfoModal from '@components/modal/ActivityInfoModal/ActivityInfoModal';
 
 import { TABLE_HEAD } from '@constants/head';
 import { ACTIVITY_STATE } from '@constants/state';
 import useModal from '@hooks/common/useModal';
+import { usePagination } from '@hooks/common/usePagination';
 import { useActivityGroupMember } from '@hooks/queries';
 import { useActivityGroupDeleteMutation } from '@hooks/queries/activity/useActivityGroupDeleteMutation';
 import { useActivityGroupStatusMutation } from '@hooks/queries/activity/useActivityGroupStatusMutation';
@@ -18,9 +20,17 @@ import type { ActivityGroupStatusType } from '@type/activity';
 const ManageActivitySection = () => {
   const [mode, setMode] = useState<ActivityGroupStatusType>('WAITING');
   const { openModal } = useModal();
+  const { page, size, handlePageChange } = usePagination({
+    defaultSize: 6,
+    sectionName: 'activity',
+  });
   const { activityGroupDeleteMutate } = useActivityGroupDeleteMutation();
   const { activityGroupStatusMutate } = useActivityGroupStatusMutation();
-  const { data: groupData } = useActivityGroupMember({ status: mode });
+  const { data: groupData } = useActivityGroupMember({
+    page,
+    size,
+    status: mode,
+  });
 
   const handleInfoButtonClick = (groupId: number) => {
     return openModal({
@@ -174,7 +184,16 @@ const ManageActivitySection = () => {
           </Menubar.Item>
         </Menubar>
       </Section.Header>
-      <Section.Body>{renderMode}</Section.Body>
+      <Section.Body>
+        {renderMode}
+        <Pagination
+          className="mt-4 justify-center"
+          totalItems={groupData.totalItems}
+          postLimit={size}
+          onChange={handlePageChange}
+          page={page}
+        />
+      </Section.Body>
     </Section>
   );
 };

--- a/apps/member/src/components/manage/ManageAlertSection/ManagerAlertSection.tsx
+++ b/apps/member/src/components/manage/ManageAlertSection/ManagerAlertSection.tsx
@@ -36,7 +36,9 @@ const ManagerAlertSection = ({ category }: ManagerAlertSectionProps) => {
   });
 
   const [mode, setMode] = useState<ModeState>('view');
-  const { page, size, handlePageChange } = usePagination();
+  const { page, size, handlePageChange } = usePagination({
+    sectionName: category,
+  });
 
   const title = getCategoryTitle(category);
 

--- a/apps/member/src/components/manage/ManageCalendarSection/ManageCalendarSection.tsx
+++ b/apps/member/src/components/manage/ManageCalendarSection/ManageCalendarSection.tsx
@@ -24,7 +24,9 @@ const ManageCalendarSection = () => {
   const { openModal } = useModal();
 
   const [mode, setMode] = useState<Mode>('view');
-  const { page, size, handlePageChange } = usePagination();
+  const { page, size, handlePageChange } = usePagination({
+    sectionName: 'calendar',
+  });
 
   const { data } = useSchedule({
     // 오늘 기준으로 최근 1년 부터 ~ 이번달 까지

--- a/apps/member/src/components/manage/ManageLevelSection/ManageLevelSection.tsx
+++ b/apps/member/src/components/manage/ManageLevelSection/ManageLevelSection.tsx
@@ -23,7 +23,7 @@ import { useMemberRole, useMemberRoleMutation } from '@hooks/queries/member';
 import { isNumeric } from '@utils/member';
 import { toKoreaMemberLevel } from '@utils/string';
 
-import { RoleLevelKey } from '@type/member';
+import type { RoleLevelKey } from '@type/member';
 
 type Mode = '' | 'ADMIN' | 'USER' | 'SUPER';
 
@@ -36,7 +36,6 @@ const roleColors: Record<RoleLevelKey, BadgeColorVariant> = {
   SUPER: 'red',
   ADMIN: 'blue',
   USER: 'green',
-  GUEST: 'yellow',
 };
 
 const ManageLevelSection = () => {
@@ -84,7 +83,7 @@ const ManageLevelSection = () => {
   useEffect(() => {
     navigation('/manage');
     setSearchWords('');
-  }, [mode]);
+  }, [mode, navigation]);
 
   return (
     <Section>

--- a/apps/member/src/components/manage/ManageLevelSection/ManageLevelSection.tsx
+++ b/apps/member/src/components/manage/ManageLevelSection/ManageLevelSection.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  Badge,
+  BadgeColorVariant,
+  Button,
+  Input,
+  Menubar,
+  Table,
+} from '@clab-platforms/design-system';
+import { SearchOutline } from '@clab-platforms/icon';
+
+import Pagination from '@components/common/Pagination/Pagination';
+import { Section } from '@components/common/Section';
+import Select from '@components/common/Select/Select';
+
+import { TABLE_HEAD, TABLE_HEAD_ACTION } from '@constants/head';
+import { ROLE_LEVEL } from '@constants/state';
+import { usePagination } from '@hooks/common/usePagination';
+import useToast from '@hooks/common/useToast';
+import { useMemberRole, useMemberRoleMutation } from '@hooks/queries/member';
+import { isNumeric } from '@utils/member';
+import { toKoreaMemberLevel } from '@utils/string';
+
+import { RoleLevelKey } from '@type/member';
+
+type Mode = '' | 'ADMIN' | 'USER' | 'SUPER';
+
+const roleOptions = Object.keys(ROLE_LEVEL).map((key) => ({
+  name: toKoreaMemberLevel(key as RoleLevelKey),
+  value: key as RoleLevelKey,
+}));
+
+const roleColors: Record<RoleLevelKey, BadgeColorVariant> = {
+  SUPER: 'red',
+  ADMIN: 'blue',
+  USER: 'green',
+  GUEST: 'yellow',
+};
+
+const ManageLevelSection = () => {
+  const navigation = useNavigate();
+  const toast = useToast();
+  const { page, size, handlePageChange } = usePagination({
+    defaultSize: 6,
+    sectionName: 'level',
+  });
+  const [mode, setMode] = useState<Mode>('');
+  const [searchWords, setSearchWords] = useState<string>('');
+  const [changeRole, setChangeRole] = useState(roleOptions[0].value);
+
+  const { data, refetch } = useMemberRole({
+    page: page,
+    size: size,
+    memberId: searchWords && isNumeric(searchWords) ? searchWords : undefined,
+    memberName:
+      searchWords && !isNumeric(searchWords) ? searchWords : undefined,
+    role: mode || undefined,
+  });
+
+  const { memberRoleMutation } = useMemberRoleMutation();
+
+  const handleMenubarItemClick = (mode: Mode) => {
+    setMode(mode);
+  };
+  const handleSearchClick = () => {
+    refetch();
+  };
+  const handleLevelChangeButtonClick = (memberId: string) => {
+    if (!changeRole) {
+      return toast({
+        state: 'error',
+        message: '권한을 선택해주세요',
+      });
+    } else {
+      memberRoleMutation({
+        memberId: memberId,
+        body: { role: changeRole },
+      });
+    }
+  };
+
+  useEffect(() => {
+    navigation('/manage');
+    setSearchWords('');
+  }, [mode]);
+
+  return (
+    <Section>
+      <Section.Header
+        title="멤버 관리"
+        description="멤버 목록을 조회하고 권한을 관리할 수 있어요"
+      >
+        <Menubar>
+          <Menubar.Item
+            selected={mode === ''}
+            onClick={() => handleMenubarItemClick('')}
+          >
+            전체
+          </Menubar.Item>
+          <Menubar.Item
+            selected={mode === 'SUPER'}
+            onClick={() => handleMenubarItemClick('SUPER')}
+          >
+            관리자
+          </Menubar.Item>
+          <Menubar.Item
+            selected={mode === 'ADMIN'}
+            onClick={() => handleMenubarItemClick('ADMIN')}
+          >
+            운영진
+          </Menubar.Item>
+          <Menubar.Item
+            selected={mode === 'USER'}
+            onClick={() => handleMenubarItemClick('USER')}
+          >
+            일반
+          </Menubar.Item>
+        </Menubar>
+      </Section.Header>
+      <Section.Body>
+        <div className="mb-4 flex gap-2">
+          <Input
+            className="w-full"
+            id="searchWords"
+            name="searchWords"
+            value={searchWords}
+            placeholder="학번이나 이름을 입력해주세요"
+            onChange={(e) => setSearchWords(e.target.value)}
+          />
+          <SearchOutline
+            width={24}
+            height={24}
+            className="m-auto hover:cursor-pointer"
+            onClick={() => handleSearchClick()}
+          />
+        </div>
+        <Table head={[...TABLE_HEAD.MEMBER_MANAGE_TABLE, TABLE_HEAD_ACTION]}>
+          {data.items.map(({ id, name, role }, index) => (
+            <Table.Row key={id}>
+              <Table.Cell>{index + 1 + page * size}</Table.Cell>
+              <Table.Cell>{id}</Table.Cell>
+              <Table.Cell>{name}</Table.Cell>
+              <Table.Cell>
+                <Badge color={roleColors[role]}>
+                  {toKoreaMemberLevel(role)}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell>
+                <div className="mx-auto flex items-center justify-center gap-2">
+                  <Select
+                    id="changeRole"
+                    options={roleOptions}
+                    onChange={(e) =>
+                      setChangeRole(e.target.value as RoleLevelKey)
+                    }
+                  />
+                  <Button
+                    size="sm"
+                    onClick={() => handleLevelChangeButtonClick(id)}
+                  >
+                    변경하기
+                  </Button>
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table>
+        <Pagination
+          className="mt-4 justify-center"
+          page={page}
+          postLimit={size}
+          totalItems={data.totalItems}
+          onChange={handlePageChange}
+        />
+      </Section.Body>
+    </Section>
+  );
+};
+
+export default ManageLevelSection;

--- a/apps/member/src/components/manage/ManageLibrarySection/ManageLibrarySection.tsx
+++ b/apps/member/src/components/manage/ManageLibrarySection/ManageLibrarySection.tsx
@@ -21,7 +21,9 @@ import { calculateDDay, formattedDate } from '@utils/date';
 type Mode = 'condition' | 'overdue';
 
 const ManageLibrarySection = () => {
-  const { page, size, handlePageChange } = usePagination();
+  const { page, size, handlePageChange } = usePagination({
+    sectionName: 'library',
+  });
   const { openModal } = useModal();
 
   const [mode, setMode] = useState<Mode>('condition');

--- a/apps/member/src/components/support/SupportHistorySection/SupportHistorySection.tsx
+++ b/apps/member/src/components/support/SupportHistorySection/SupportHistorySection.tsx
@@ -9,6 +9,7 @@ import MembershipStatusBadge from '@components/membership/MembershipStatusBadge/
 
 import { TABLE_HEAD } from '@constants/head';
 import { MODAL_TITLE } from '@constants/modal';
+import { ROLE_LEVEL } from '@constants/state';
 import useModal from '@hooks/common/useModal';
 import { usePagination } from '@hooks/common/usePagination';
 import { useMembershipFee, useMyProfile } from '@hooks/queries';
@@ -32,7 +33,10 @@ const SupportHistorySection = ({
   hasPermission = false,
 }: Props) => {
   const { openModal } = useModal();
-  const { page, size, handlePageChange } = usePagination(defaultSize);
+  const { page, size, handlePageChange } = usePagination({
+    defaultSize,
+    sectionName: 'history',
+  });
 
   const { data: myProfile } = useMyProfile();
   const { membershipFeeModifyMutate } = useMembershipFeeModifyMutation();
@@ -47,7 +51,7 @@ const SupportHistorySection = ({
    */
   const handleButtonClick = useCallback(
     (membership: MembershipFeeType) => {
-      const isAdminLevel = myProfile.roleLevel! >= 3;
+      const isAdminLevel = myProfile.roleLevel! >= ROLE_LEVEL.SUPER;
 
       openModal({
         title: MODAL_TITLE.SUPPORT_HISTORY,

--- a/apps/member/src/constants/api.ts
+++ b/apps/member/src/constants/api.ts
@@ -20,6 +20,9 @@ export const END_POINT = {
   MY_NOTIFICATION: '/v1/notifications',
   MY_COMMENTS: '/v1/comments/my-comments',
   MY_INFO_EDIT: (id: string) => `/v1/members/${id}`,
+  // 멤버 래밸 관리
+  MEMBER_LEVEL: `/v1/members/roles`,
+  MEMBER_LEVEL_EDIT: (memberId: string) => `/v1/members/${memberId}/roles`,
   // -- 커뮤니티
   BOARDS: `/v1/boards`,
   BOARDS_LIST: `/v1/boards/category`,

--- a/apps/member/src/constants/head.ts
+++ b/apps/member/src/constants/head.ts
@@ -39,6 +39,7 @@ export const TABLE_HEAD = {
     '합불 처리',
     '생성',
   ] as const,
+  MEMBER_MANAGE_TABLE: ['번호', '학번', '이름', '상태'],
 } as const;
 /**
  * 관리자 페이지에서 기능을 나타내는 상수

--- a/apps/member/src/constants/key.ts
+++ b/apps/member/src/constants/key.ts
@@ -4,6 +4,7 @@ import type {
 } from '@type/activity';
 import type { WithPaginationParams } from '@type/api';
 import type { CommunityCategoryType } from '@type/community';
+import { RoleLevelKey } from '@type/member';
 
 /**
  * 전역 상태 관리 키
@@ -23,6 +24,12 @@ export const MEMBER_QUERY_KEY = {
   COMMENTS: () => [...MEMBER_QUERY_KEY.ALL, 'comments'],
   MEMBERS: () => [...MEMBER_QUERY_KEY.ALL, 'members'],
   MEMBER: (memberId: string) => [...MEMBER_QUERY_KEY.MEMBERS(), memberId],
+  PAGES: () => [...MEMBER_QUERY_KEY.ALL, 'pages'],
+  PAGE: (pagination: WithPaginationParams, role?: RoleLevelKey) => [
+    ...MEMBER_QUERY_KEY.PAGES(),
+    pagination,
+    role,
+  ],
 } as const;
 
 /**

--- a/apps/member/src/constants/state.ts
+++ b/apps/member/src/constants/state.ts
@@ -102,5 +102,4 @@ export const ROLE_LEVEL = {
   SUPER: 3,
   ADMIN: 2,
   USER: 1,
-  GUEST: 0,
 } as const;

--- a/apps/member/src/constants/state.ts
+++ b/apps/member/src/constants/state.ts
@@ -94,3 +94,13 @@ export const ACTIVITY_BOARD_CATEGORY_STATE = {
   ASSIGNMENT: 'ASSIGNMENT',
   SUBMIT: 'SUBMIT',
 } as const;
+
+/**
+ * 멤버 권한을 정의합니다.
+ */
+export const ROLE_LEVEL = {
+  SUPER: 3,
+  ADMIN: 2,
+  USER: 1,
+  GUEST: 0,
+} as const;

--- a/apps/member/src/hooks/common/usePagination.ts
+++ b/apps/member/src/hooks/common/usePagination.ts
@@ -5,14 +5,22 @@ import { useLocation, useNavigate } from 'react-router-dom';
  * 페이지네이션을 위한 페이지 조작 훅입니다.
  * Pagination Component와 같이 사용합니다.
  */
-export const usePagination = (defaultSize: number = 20) => {
+interface UsePaginationProps {
+  defaultSize?: number;
+  sectionName?: string;
+}
+
+export const usePagination = ({
+  defaultSize = 20,
+  sectionName = 'page',
+}: UsePaginationProps = {}) => {
   const navigate = useNavigate();
   const location = useLocation();
 
   const getPage = useCallback(() => {
     const searchParams = new URLSearchParams(location.search);
-    return parseInt(searchParams.get('page') ?? '1', 10) - 1;
-  }, [location.search]);
+    return parseInt(searchParams.get(sectionName) ?? '1', 10) - 1;
+  }, [location.search, sectionName]);
 
   const [pagination, setPagination] = useState({
     page: getPage(),
@@ -21,9 +29,9 @@ export const usePagination = (defaultSize: number = 20) => {
 
   const handlePageChange = useCallback(
     (page: number) => {
-      navigate('?page=' + page);
+      navigate(`?${sectionName}=` + page);
     },
-    [navigate],
+    [navigate, sectionName],
   );
 
   useEffect(() => {

--- a/apps/member/src/hooks/common/usePagination.ts
+++ b/apps/member/src/hooks/common/usePagination.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { createQueryParams } from '@utils/string';
+
 /**
  * 페이지네이션을 위한 페이지 조작 훅입니다.
  * Pagination Component와 같이 사용합니다.
@@ -29,7 +31,8 @@ export const usePagination = ({
 
   const handlePageChange = useCallback(
     (page: number) => {
-      navigate(`?${sectionName}=` + page);
+      const queryParams = createQueryParams(sectionName, page);
+      navigate(queryParams);
     },
     [navigate, sectionName],
   );

--- a/apps/member/src/hooks/queries/member/index.ts
+++ b/apps/member/src/hooks/queries/member/index.ts
@@ -1,0 +1,2 @@
+export * from './useMemberRole';
+export * from './useMemberRoleMutation';

--- a/apps/member/src/hooks/queries/member/useMemberRole.ts
+++ b/apps/member/src/hooks/queries/member/useMemberRole.ts
@@ -4,7 +4,7 @@ import { getMemberRole } from '@api/member';
 import { MEMBER_QUERY_KEY } from '@constants/key';
 
 import { WithPaginationParams } from '@type/api';
-import { RoleLevelKey } from '@type/member';
+import type { RoleLevelKey } from '@type/member';
 
 interface useMemberRoleParams extends WithPaginationParams {
   memberId?: string;

--- a/apps/member/src/hooks/queries/member/useMemberRole.ts
+++ b/apps/member/src/hooks/queries/member/useMemberRole.ts
@@ -1,0 +1,38 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMemberRole } from '@api/member';
+import { MEMBER_QUERY_KEY } from '@constants/key';
+
+import { WithPaginationParams } from '@type/api';
+import { RoleLevelKey } from '@type/member';
+
+interface useMemberRoleParams extends WithPaginationParams {
+  memberId?: string;
+  memberName?: string;
+  role?: RoleLevelKey;
+  sortBy?: string;
+  sortDirection?: string;
+}
+export function useMemberRole({
+  memberId,
+  memberName,
+  role,
+  page = 0,
+  size = 6,
+  sortBy,
+  sortDirection,
+}: useMemberRoleParams) {
+  return useSuspenseQuery({
+    queryKey: MEMBER_QUERY_KEY.PAGE({ page, size }, role),
+    queryFn: () =>
+      getMemberRole({
+        memberId,
+        memberName,
+        role,
+        page,
+        size,
+        sortBy,
+        sortDirection,
+      }),
+  });
+}

--- a/apps/member/src/hooks/queries/member/useMemberRoleMutation.ts
+++ b/apps/member/src/hooks/queries/member/useMemberRoleMutation.ts
@@ -20,12 +20,12 @@ export const useMemberRoleMutation = () => {
         });
         toast({
           state: 'success',
-          message: '레벨이 수정되었어요.',
+          message: '사용자 권한이 변경되었어요.',
         });
       } else {
         toast({
           state: 'error',
-          message: '레벨 수정에 실패했어요',
+          message: '사용자 권한 변경에 실패했어요.',
         });
       }
     },

--- a/apps/member/src/hooks/queries/member/useMemberRoleMutation.ts
+++ b/apps/member/src/hooks/queries/member/useMemberRoleMutation.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { patchMemberRole } from '@api/member';
+import { MEMBER_QUERY_KEY } from '@constants/key';
+import useToast from '@hooks/common/useToast';
+
+/**
+ * 멤버 레벨을 수정합니다.
+ */
+export const useMemberRoleMutation = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const mutation = useMutation({
+    mutationFn: patchMemberRole,
+    onSuccess: (data) => {
+      if (data) {
+        queryClient.invalidateQueries({
+          queryKey: MEMBER_QUERY_KEY.PAGES(),
+        });
+        toast({
+          state: 'success',
+          message: '레벨이 수정되었어요.',
+        });
+      } else {
+        toast({
+          state: 'error',
+          message: '레벨 수정에 실패했어요',
+        });
+      }
+    },
+  });
+
+  return { memberRoleMutation: mutation.mutate };
+};

--- a/apps/member/src/pages/ApplicationPage/ApplicationPage.tsx
+++ b/apps/member/src/pages/ApplicationPage/ApplicationPage.tsx
@@ -4,6 +4,7 @@ import ApplicationListSection from '@components/application/ApplicationListSecti
 import Content from '@components/common/Content/Content';
 import Header from '@components/common/Header/Header';
 
+import { ROLE_LEVEL } from '@constants/state';
 import { useMyProfile } from '@hooks/queries';
 import { useRecruitment } from '@hooks/queries/recruitment/useRecruitment';
 import { formattedDate } from '@utils/date';
@@ -18,7 +19,7 @@ const ApplicationPage = () => {
     name: `${item.applicationType} - ${formattedDate(item.startDate)} ~ ${formattedDate(item.endDate)}`,
   }));
 
-  if (data.roleLevel! < 2) {
+  if (data.roleLevel! < ROLE_LEVEL.ADMIN) {
     throw new Error('접근 권한이 없습니다.');
   }
 

--- a/apps/member/src/pages/ManagePage/ManagePage.tsx
+++ b/apps/member/src/pages/ManagePage/ManagePage.tsx
@@ -9,12 +9,13 @@ import ManageCalendarSection from '@components/manage/ManageCalendarSection/Mana
 import ManageLibrarySection from '@components/manage/ManageLibrarySection/ManageLibrarySection';
 import SupportHistorySection from '@components/support/SupportHistorySection/SupportHistorySection';
 
+import { ROLE_LEVEL } from '@constants/state';
 import { useMyProfile } from '@hooks/queries';
 
 const ManagePage = () => {
   const { data } = useMyProfile();
 
-  if (data.roleLevel! < 2) {
+  if (data.roleLevel! < ROLE_LEVEL.ADMIN) {
     throw new Error('접근 권한이 없습니다.');
   }
 

--- a/apps/member/src/pages/ManagePage/ManagePage.tsx
+++ b/apps/member/src/pages/ManagePage/ManagePage.tsx
@@ -6,6 +6,7 @@ import ManageActivitySection from '@components/manage/ManageActivitySection/Mana
 import ManagerAlertSection from '@components/manage/ManageAlertSection/ManagerAlertSection';
 import ManageBannerSection from '@components/manage/ManageBannerSection/ManageBannerSection';
 import ManageCalendarSection from '@components/manage/ManageCalendarSection/ManageCalendarSection';
+import ManageLevelSection from '@components/manage/ManageLevelSection/ManageLevelSection';
 import ManageLibrarySection from '@components/manage/ManageLibrarySection/ManageLibrarySection';
 import SupportHistorySection from '@components/support/SupportHistorySection/SupportHistorySection';
 
@@ -36,6 +37,9 @@ const ManagePage = () => {
       </Suspense>
       <Suspense>
         <ManageCalendarSection />
+      </Suspense>
+      <Suspense>
+        <ManageLevelSection />
       </Suspense>
       <Suspense>
         <ManageActivitySection />

--- a/apps/member/src/types/comment.ts
+++ b/apps/member/src/types/comment.ts
@@ -1,5 +1,5 @@
 import type { CommunityCategoryType } from './community';
-import type { RoleLevel } from './member';
+import type { RoleLevelType } from './member';
 
 export interface CommentItem {
   id: number;
@@ -16,7 +16,7 @@ export interface CommentItem {
 
 export interface CommentListItem extends CommentItem {
   writerId: string | null;
-  writerRoleLevel: RoleLevel;
+  writerRoleLevel: RoleLevelType;
   children: Array<CommentListItem>;
   isOwner: boolean;
   isDeleted: boolean;

--- a/apps/member/src/types/community.ts
+++ b/apps/member/src/types/community.ts
@@ -1,4 +1,4 @@
-import type { RoleLevel } from './member';
+import type { RoleLevelType } from './member';
 
 export type CommunityCategoryType =
   | 'notice'
@@ -67,7 +67,7 @@ export interface CommunityWriteItem {
 }
 
 export interface CommunityPostDetailItem extends CommunityPostItem {
-  writerRoleLevel: RoleLevel; // 익명일 경우 null
+  writerRoleLevel: RoleLevelType; // 익명일 경우 null
   writerImageUrl: string | null; // 기본 사진일 경우 null
   content: string;
   likes: number;

--- a/apps/member/src/types/member.ts
+++ b/apps/member/src/types/member.ts
@@ -1,8 +1,14 @@
+import { ROLE_LEVEL } from '@constants/state';
+
 /**
  * 계정의 권한 레벨
  * 익명일 경우 null
  */
-export type RoleLevel = 1 | 2 | 3 | null;
+export type RoleLevelType = (typeof ROLE_LEVEL)[keyof typeof ROLE_LEVEL];
+/**
+ * 계정 권한의 string
+ */
+export type RoleLevelKey = keyof typeof ROLE_LEVEL;
 
 /**
  * 멤버 정보
@@ -29,7 +35,7 @@ export interface MemberInfo {
  * 멤버 프로필 정보
  */
 export interface MemberProfileType extends MemberInfo {
-  roleLevel: RoleLevel;
+  roleLevel: RoleLevelType;
   password?: string;
 }
 /**

--- a/apps/member/src/types/member.ts
+++ b/apps/member/src/types/member.ts
@@ -53,3 +53,19 @@ export interface MemberProfileRequestType {
   studentStatus?: string;
   imageUrl?: string | null;
 }
+
+/**
+ * 멤버 레벨 목록
+ */
+export interface MemberRoleListType {
+  id: string;
+  name: string;
+  role: RoleLevelKey;
+}
+
+/**
+ * 멤버 레벨 변경
+ */
+export interface MemberRoleRequestType {
+  role: RoleLevelKey;
+}

--- a/apps/member/src/utils/member.ts
+++ b/apps/member/src/utils/member.ts
@@ -1,0 +1,6 @@
+/**
+ * 주어진 문자가 숫자로만 이루어져 있는지 확인합니다.
+ * @param {string} value 입력 문자
+ * @returns {boolean}숫자로 된 문자열인지 판단한 boolean 값
+ */
+export const isNumeric = (value: string) => /^\d+$/.test(value);

--- a/apps/member/src/utils/string.ts
+++ b/apps/member/src/utils/string.ts
@@ -150,3 +150,7 @@ export function toKoreaMemberLevel(
       return '-';
   }
 }
+
+export const createQueryParams = (name: string, page: number) => {
+  return `?${name}=${page}`;
+};

--- a/apps/member/src/utils/string.ts
+++ b/apps/member/src/utils/string.ts
@@ -2,6 +2,7 @@ import { SERVICE_NAME } from '@constants/environment';
 
 import type { Bookstore, BookstoreKorean } from '@type/book';
 import type { CareerLevel, EmploymentType } from '@type/community';
+import { RoleLevelKey, RoleLevelType } from '@type/member';
 import type { MembershipStatusType } from '@type/membershipFee';
 import type { SchedulePriority } from '@type/schedule';
 
@@ -127,6 +128,27 @@ export function toKoreaEmploymentType(employmentType: EmploymentType | null) {
       return '어시스턴트';
     case 'PART_TIME':
       return '파트타임';
+    default:
+      return '-';
+  }
+}
+
+export function toKoreaMemberLevel(
+  memberLevel: RoleLevelKey | RoleLevelType | null,
+) {
+  switch (memberLevel) {
+    case 'GUEST':
+    case 0:
+      return '게스트';
+    case 'USER':
+    case 1:
+      return '일반';
+    case 'ADMIN':
+    case 2:
+      return '운영진';
+    case 'SUPER':
+    case 3:
+      return '관리자';
     default:
       return '-';
   }

--- a/apps/member/src/utils/string.ts
+++ b/apps/member/src/utils/string.ts
@@ -137,9 +137,6 @@ export function toKoreaMemberLevel(
   memberLevel: RoleLevelKey | RoleLevelType | null,
 ) {
   switch (memberLevel) {
-    case 'GUEST':
-    case 0:
-      return '게스트';
     case 'USER':
     case 1:
       return '일반';


### PR DESCRIPTION
## Summary

#216

동아리 멤버의 권한을 관리하는 기능을 추가합니다. 관리 페이지 내에서 특정 인원의 권한을 조정할 수 있습니다.

## Tasks

- 멤버 권한 상수화
- 멤버 권한 변경 기능
- 권한 별 멤버 조회
- 이름, id 통한 멤버 검색
- 한 페이지 내에 여러 개의 `pagination`이 존재하는 경우, 한 `pagination`의 page 이동 시 다른 `pagination`의 page 또한 움직여지는 문제 해결

## Screenshot

<img width="1552" alt="스크린샷 2024-08-22 오후 6 24 49" src="https://github.com/user-attachments/assets/fa1f8d13-4b55-4e32-8a41-aff4f591d56b">
<img width="1552" alt="스크린샷 2024-08-22 오후 6 25 04" src="https://github.com/user-attachments/assets/c9b654a9-40d4-437f-9e72-edaeed6d3a25">
<img width="1552" alt="스크린샷 2024-08-22 오후 6 25 12" src="https://github.com/user-attachments/assets/22d608cc-a6cf-4d8a-b4a6-3ed9024271d4">
